### PR TITLE
Templatable contextname

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ GLOBAL OPTIONS:
    --ca value                    The value of the CA data to put in the Kubeconfig [$CA]
    --default-cluster-role value  Default cluster-role to assign to users with no roles (default: "cluster-admin") [$DEFAULT_CLUSTER_ROLE]
 ```
+Note: CONTEXT_NAME is golang tempate avare. The only available context var is UserName. For example
+if you want to postfix contextname with username, set CONTEXT_NAME=`default-{{ .UserName }}`.
 
 ## Building
 

--- a/scripts/build
+++ b/scripts/build
@@ -9,8 +9,9 @@ mkdir -p bin
 if [ "$(uname)" = "Linux" ]; then
     OTHER_LINKFLAGS="-extldflags -static -s"
 fi
-LINKFLAGS="-X github.com/rancher/klum.Version=$VERSION"
-LINKFLAGS="-X github.com/rancher/klum.GitCommit=$COMMIT $LINKFLAGS"
+LINKFLAGS="-X main.Version=$VERSION"
+LINKFLAGS="-X main.GitCommit=$COMMIT $LINKFLAGS"
+
 CGO_ENABLED=0 go build -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -o bin/klum
 if [ "$CROSS" = "true" ] && [ "$ARCH" = "amd64" ]; then
     GOOS=darwin go build -ldflags "$LINKFLAGS" -o bin/klum-darwin


### PR DESCRIPTION
## Use-case

when I create multiple users and save the kubeconfig as documented
```
kubectl get kubeconfig darren -o json | jq .spec > kubeconfig-darren
kubectl get kubeconfig lalyos -o json | jq .spec > kubeconfig-lalyos
```
Usually its easier to switch between context, than switching between KUBECONFIGs,
so usuallymerge the together as:
```
export KUBECONFIG=$KUBECONFIG:./kubeconfig-darren:./kubeconfig-lalyos
```
but if KLUM has a fixed contextName it doesn't work. 

## Proposed solution

Instead of a fixed string `context-name` let's make it a golang template. For example:
```
CONTEXT_NAME=workshop-{{ .UserName }}
```
with the above KUBECONFIG merge it has distinct contexts:
```
k config get-contexts 
CURRENT   NAME              CLUSTER           AUTHINFO          NAMESPACE
*         boss              singli            singli            klum
          workshop-darren   workshop-darren   workshop-darren     
          workshop-lalyos   workshop-lalyos   workshop-lalyos
```

## why send the PR
I've seen at dockerhub that the image was updated "4 months ago" and it has 8k pulls, so why not?